### PR TITLE
Caio videmelo patch 1

### DIFF
--- a/PokeDIO.sol
+++ b/PokeDIO.sol
@@ -1,14 +1,17 @@
 // SPDX-License-Identifier: GPL-3.0
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.24;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 
 contract PokeDIO is ERC721 {
+    enum EvolutionState { None, Evolved }
+
     struct Pokemon {
         string name;
         uint level;
         string img;
+        EvolutionState evolutionState;
     }
 
     Pokemon[] public pokemons;
@@ -26,6 +29,34 @@ contract PokeDIO is ERC721 {
         _;
     }
 
+    function createNewPokemon(
+        string memory _name,
+        address _to,
+        string memory _img
+    ) public {
+        require(
+            msg.sender == gameOwner,
+            "Apenas o dono do jogo pode criar novos Pokemons"
+        );
+        uint id = pokemons.length;
+        pokemons.push(Pokemon(_name, 1, _img, EvolutionState.None));
+        _safeMint(_to, id);
+    }
+
+    function evolvePokemon(uint _pokemonId) public onlyOwnerOf(_pokemonId) {
+        Pokemon storage pokemon = pokemons[_pokemonId];
+        
+        require(pokemon.level >= 10, "O Pokemon deve estar no nível 10 ou superior para evoluir.");
+        
+        // Atualiza o estado de evolução
+        pokemon.evolutionState = EvolutionState.Evolved;
+
+        // Aqui você pode definir a nova forma do Pokémon, se necessário
+        // Exemplo de mudança de nome ou imagem após a evolução
+        // pokemon.name = "Novo Nome"; // Defina o novo nome
+        // pokemon.img = "Nova Imagem"; // Defina a nova imagem
+    }
+
     function battle(
         uint _attackingPokemon,
         uint _defendingPokemon
@@ -40,19 +71,10 @@ contract PokeDIO is ERC721 {
             attacker.level += 1;
             defender.level += 2;
         }
-    }
 
-    function createNewPokemon(
-        string memory _name,
-        address _to,
-        string memory _img
-    ) public {
-        require(
-            msg.sender == gameOwner,
-            "Apenas o dono do jogo pode criar novos Pokemons"
-        );
-        uint id = pokemons.length;
-        pokemons.push(Pokemon(_name, 1, _img));
-        _safeMint(_to, id);
+        // Verifica se o Pokémon atacante pode evoluir
+        if (attacker.level >= 10 && attacker.evolutionState == EvolutionState.None) {
+            evolvePokemon(_attackingPokemon);
+        }
     }
 }

--- a/PokeDIO.sol
+++ b/PokeDIO.sol
@@ -51,10 +51,15 @@ contract PokeDIO is ERC721 {
         // Atualiza o estado de evolução
         pokemon.evolutionState = EvolutionState.Evolved;
 
-        // Aqui você pode definir a nova forma do Pokémon, se necessário
-        // Exemplo de mudança de nome ou imagem após a evolução
-        // pokemon.name = "Novo Nome"; // Defina o novo nome
-        // pokemon.img = "Nova Imagem"; // Defina a nova imagem
+        // Exemplo de mudança de nome e imagem após a evolução
+        if (keccak256(abi.encodePacked(pokemon.name)) == keccak256(abi.encodePacked("Pikachu"))) {
+            pokemon.name = "Raichu"; // Nome após evolução
+            pokemon.img = "url_da_imagem_de_raichu"; // URL da nova imagem
+        } else if (keccak256(abi.encodePacked(pokemon.name)) == keccak256(abi.encodePacked("Charmander"))) {
+            pokemon.name = "Charmeleon"; // Nome após evolução
+            pokemon.img = "url_da_imagem_de_charmeleon"; // URL da nova imagem
+        }
+        // Adicione mais condições conforme necessário para outros Pokémons
     }
 
     function battle(

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ PokeDIO é um contrato inteligente baseado no Ethereum para a criação e batalh
 
 1. Clone o repositório:
     ```bash
-    git clone https://github.com/mario-evangelista/nft-pokemon-blockchain.git
+    git clone https://github.com/caio.videmelo/nft-pokemon-blockchain.git
     cd nft-pokemon-blockchain
     ```
 
@@ -64,6 +64,36 @@ function battle(uint _attackingPokemon, uint _defendingPokemon) public onlyOwner
 ```
 Permite ao proprietário de um Pokémon batalhar contra outro Pokémon. O nível dos Pokémons será atualizado com base no resultado da batalha.
 
+## Explicação:
+
+### Estrutura do Contrato
+
+O contrato importa a interface ERC721 do OpenZeppelin, que fornece as funcionalidades básicas para tokens NFT.
+
+O contrato define um struct chamado Pokemon para armazenar as informações de cada Pokémon: nome, nível e URL da imagem.
+
+Um array dinâmico chamado pokemons é usado para armazenar todos os Pokémons criados. O endereço do proprietário do jogo é armazenado na variável gameOwner.
+
+O construtor inicializa o nome e símbolo do token NFT como "PokeDIO" e "PKD", respectivamente. Ele também define o endereço do proprietário do jogo como o endereço do criador do contrato.
+
+### Modificador de Acesso
+
+O modificador onlyOwnerOf verifica se o chamador da função é o proprietário do Pokémon especificado pelo ID. Ele usa a função ownerOf herdada do ERC721 para verificar a propriedade.
+
+### Função de Batalha
+
+A função battle permite que um jogador batalhe com seus Pokémons. Ela verifica se o chamador é o proprietário do Pokémon de ataque usando o modificador onlyOwnerOf.
+
+A função então compara os níveis dos Pokémons de ataque e defesa. Se o nível do Pokémon de ataque for maior ou igual ao do defesa, o nível do atacante aumenta em 2 e o do defensor em 1. Caso contrário, o nível do atacante aumenta em 1 e o do defensor em 2.
+
+### Função de Criação de Pokémon
+
+A função createNewPokemon permite que o proprietário do jogo crie novos Pokémons. Ela verifica se o chamador é o proprietário do jogo usando uma declaração require.
+
+A função então gera um novo ID para o Pokémon com base no tamanho atual do array pokemons. Ela cria um novo Pokémon com o nome, nível inicial 1, URL da imagem fornecida e adiciona-o ao array.
+
+Finalmente, a função usa _safeMint herdado do ERC721 para cunhar um novo token NFT com o ID gerado e atribuí-lo ao endereço fornecido.
+
 ## Contribuição
 
 1. Faça um fork do projeto
@@ -78,4 +108,4 @@ Este projeto está licenciado sob a Licença GPL-3.0. Veja o arquivo [LICENSE](L
 
 ## Contato
 
-Para dúvidas ou sugestões, entre em contato pelo email: seu-email@dominio.com
+Para dúvidas ou sugestões, entre em contato pelo email: caio.videmelo@gmail.com

--- a/README.md
+++ b/README.md
@@ -110,7 +110,17 @@ Ao criar um novo Pokémon, o estado de evolução é inicializado como None.
 
 Esta função permite que o proprietário do Pokémon evolua seu Pokémon quando ele atinge o nível 10.
 
-Você pode adicionar lógica para alterar o nome ou a imagem do Pokémon após a evolução, se desejar.
+3.1. Lógica de Evolução
+
+Na função evolvePokemon, após verificar se o Pokémon pode evoluir, adicionamos lógica para alterar o nome e a imagem do Pokémon:
+
+Comparação de Nomes: Foi utilizado keccak256 para comparar strings (nomes dos Pokémons) de forma segura. Isso é necessário porque Solidity não possui um operador de comparação de strings nativo.
+
+Alteração de Nome e Imagem: Dependendo do nome do Pokémon antes da evolução, altera-se o nome e a URL da imagem para os novos valores correspondentes.
+
+3.2. Exemplos de Evolução
+
+Incluímos evoluções para dois Pokémons: Pikachu evoluindo para Raichu e Charmander evoluindo para Charmeleon. 
 
 4. Função battle
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,28 @@ A função então gera um novo ID para o Pokémon com base no tamanho atual do a
 
 Finalmente, a função usa _safeMint herdado do ERC721 para cunhar um novo token NFT com o ID gerado e atribuí-lo ao endereço fornecido.
 
+## Explicação das Modificações propostas:
+
+1. Enum e Struct
+
+Enum EvolutionState: Define dois estados possíveis para a evolução dos Pokémons: None (não evoluído) e Evolved (evoluído).
+
+Struct Pokemon: Agora inclui o campo evolutionState para rastrear o estado de evolução de cada Pokémon.
+
+2. Função createNewPokemon
+
+Ao criar um novo Pokémon, o estado de evolução é inicializado como None.
+
+3. Função evolvePokemon
+
+Esta função permite que o proprietário do Pokémon evolua seu Pokémon quando ele atinge o nível 10.
+
+Você pode adicionar lógica para alterar o nome ou a imagem do Pokémon após a evolução, se desejar.
+
+4. Função battle
+
+A função de batalha agora verifica se o Pokémon atacante pode evoluir após a batalha e chama evolvePokemon se as condições forem atendidas.
+
 ## Contribuição
 
 1. Faça um fork do projeto


### PR DESCRIPTION
Resumo das Modificações:
Atualização da versão do pragma solidity para 0.8.24
Adição do Enum EvolutionState:
Definido um enum para representar os estados de evolução: None (não evoluído) e Evolved (evoluído).
Modificação do Struct Pokemon:
Adicionado o campo evolutionState ao struct Pokemon para rastrear o estado de evolução de cada Pokémon.
Atualização da Função createNewPokemon:
Ao criar um novo Pokémon, o estado de evolução é inicializado como None.
Implementação da Função evolvePokemon:
Essa função permite que o proprietário do Pokémon evolua seu Pokémon quando ele atinge o nível 10.
Verifica se o Pokémon atende aos requisitos de evolução (nível mínimo).
Atualiza o estado de evolução do Pokémon para Evolved.
Opcionalmente, você pode adicionar lógica para alterar o nome ou a imagem do Pokémon após a evolução.
Modificação da Função battle:
Adicionada uma verificação na função de batalha para ver se o Pokémon atacante pode evoluir após a batalha.
Se as condições forem atendidas (nível mínimo e estado de evolução None), a função evolvePokemon é chamada para evoluir o Pokémon.
Exemplo de Alteração de Nome e Imagem após a Evolução:
Na função evolvePokemon, adicionado um exemplo de lógica para alterar o nome e a imagem de Pokémons específicos após a evolução.
Usado keccak256 para comparar strings de forma segura.
Alterado o nome e a URL da imagem do Pokémon evoluído.